### PR TITLE
Fix when crashes with "Unterminated string starting at"/Fix when form has ";" in it

### DIFF
--- a/form.py
+++ b/form.py
@@ -30,13 +30,13 @@ def get_form_response_url(url: str):
         url += 'formResponse'
     return url
 
-def extract_script_variables(name :str, html: str):
+def extract_script_variables(name:str, html: str):
     """ Extract a variable from a script tag in a HTML page """
-    pattern = re.compile(r'var\s' + name + r'\s=\s(.*?);')
+    pattern = re.compile(r'var\s' + name + r'\s=\s(.*?)\];')
     match = pattern.search(html)
     if not match:
         return None
-    value_str = match.group(1)
+    value_str = match.group(1) + ']'
     return json.loads(value_str)
 
 def get_fb_public_load_data(url: str):


### PR DESCRIPTION
When form has ';' in any text field (form description. question) `extract_script_variables` crashes with `json.decoder.JSONDecodeError: Unterminated string starting at: line 1 column 8 (char 7)` (or smth like that).

Changes to regex fix this issue.